### PR TITLE
fix(apps): ignore uninstalled preset permissions

### DIFF
--- a/core/src/runtime/planner.rs
+++ b/core/src/runtime/planner.rs
@@ -354,6 +354,10 @@ impl<H: FileSystemObservationHost> CoreRuntime<H> {
             .collect::<BTreeSet<_>>();
 
         for category in categories {
+            let installed_category = installed_categories.contains(&category.name);
+            if request.operation != LifecycleOperation::Install && !installed_category {
+                continue;
+            }
             permissions.declaration(
                 category.permissions.as_ref(),
                 "app_permission_declaration_missing",
@@ -373,13 +377,6 @@ impl<H: FileSystemObservationHost> CoreRuntime<H> {
                 let direct = manifest.find_by_dest(&destination);
                 let by_source = manifest.find_by_source(&source);
                 let entry = by_source.or_else(|| direct.filter(|entry| entry.source == source));
-                let installed_category = installed_categories.contains(&category.name);
-                if request.operation != LifecycleOperation::Install
-                    && entry.is_none()
-                    && !installed_category
-                {
-                    continue;
-                }
 
                 capture_path_state(
                     self.host(),
@@ -6721,6 +6718,55 @@ install = {{ kind = 'package', provider = 'homebrew', package = 'tool' }}
                 | super::super::HostOperation::Run { .. }
                 | super::super::HostOperation::ApplySplitDns { .. }
         )));
+    }
+
+    #[tokio::test]
+    async fn app_upgrade_ignores_permissions_from_uninstalled_presets() {
+        let snapshot = PresetSnapshot::builder(PresetSourceKind::Embedded)
+            .file(
+                "app/demo/shine.toml",
+                b"dest = '~/.config/demo'\n[permissions]\nschema_version = 1\n[[files]]\nsource = 'config.toml'\n".to_vec(),
+            )
+            .file("app/demo/config.toml", b"managed".to_vec())
+            .file(
+                "app/admin/shine.toml",
+                b"dest = '/etc/admin'\n[permissions]\nschema_version = 1\nadministrator = true\n[[files]]\nsource = 'config.toml'\nrequires_admin = true\n".to_vec(),
+            )
+            .file("app/admin/config.toml", b"managed".to_vec())
+            .file(
+                "app/legacy/shine.toml",
+                b"dest = '~/.config/legacy'\n[[files]]\nsource = 'config.toml'\n".to_vec(),
+            )
+            .file("app/legacy/config.toml", b"managed".to_vec())
+            .build();
+        let runtime = runtime(snapshot);
+        seed_static_copy_app(&runtime, b"managed", None).await;
+
+        let plan = runtime
+            .plan_apps(AppPlanRequest {
+                operation: LifecycleOperation::Upgrade,
+                target: None,
+                force: false,
+                purge: false,
+                prune_stale: false,
+                input_versions: PlanningInputVersions::default(),
+            })
+            .await
+            .unwrap();
+
+        assert!(plan.is_ready());
+        assert!(
+            !plan
+                .permissions
+                .required
+                .contains(&PermissionV1::Administrator)
+        );
+        assert!(plan.permissions.uncomputable_codes.is_empty());
+        assert!(
+            plan.steps
+                .iter()
+                .all(|step| step.target != "app/admin" && step.target != "app/legacy")
+        );
     }
 
     #[tokio::test]

--- a/docs/kb/architecture/invariants.md
+++ b/docs/kb/architecture/invariants.md
@@ -62,6 +62,9 @@ bugs. Check this list before changing the modules named in each entry.
 - **A Preset permission declaration is not a grant.** App categories, Shell commands, and Sys items
   may declare schema-v1 capability identities, but those declarations do not create scoped
   external-code trust or bypass administrator authorization, ownership checks, or Plan approval.
+  Untargeted upgrade includes declarations only from installed App categories, installed Shell
+  commands, and enabled managed Sys items; merely available embedded, external, or overlay Presets
+  cannot contribute required permissions or missing-declaration blockers.
   Filesystem declarations use logical bases and never embed a physical Preset
   checkout path; command entries contain no argv and environment entries contain names and
   sensitivity only. Pure planners merge explicit declarations with Core-bounded typed metadata and

--- a/docs/kb/lessons.md
+++ b/docs/kb/lessons.md
@@ -3,6 +3,19 @@
 Dated entries mined from real bugs. Format: **symptom → root cause → fix → rule**.
 Newest first. Cite the fixing commit. Add an entry whenever a bug's cause was non-obvious.
 
+## 2026-09-02 — Available Presets are not upgrade permission targets
+
+- **Symptom**: an untargeted App upgrade requested administrator and opaque-code capabilities from
+  built-in Presets that were available in the snapshot but had never been installed; a legacy
+  uninstalled Preset could also block the entire Plan for a missing permission declaration.
+- **Root cause**: App convergence merged each category declaration before checking the App manifest,
+  while file planning performed the installed-category check later.
+- **Fix**: filter non-install App categories by manifest ownership before merging declarations,
+  cache work, file permissions, or blockers.
+- **Rule**: availability in the effective Preset snapshot is not lifecycle selection; collect
+  permissions only after the operation has established that the target is installed or explicitly
+  selected for installation.
+
 ## 2026-09-01 — File identity compares permission bits, not Unix file-type bits
 
 - **Symptom**: normal CLI Shell installs wrote the exact new profile bytes and mode, but receipt

--- a/docs/manual/reference/commands.md
+++ b/docs/manual/reference/commands.md
@@ -244,7 +244,9 @@ evaluation failures are reported after the remaining selected generators run.
 - `update/upgrade --pull` synchronizes Git-managed sources and reloads configuration first.
 - Untargeted `upgrade` reviews Shell, App, and enabled managed-system Plans together, confirms once,
   and revalidates all of them before applying changes. It no longer changes Sys profile enablement
-  or composition implicitly.
+  or composition implicitly. Its required permissions and missing-declaration checks include only
+  installed App categories, installed Shell commands, and enabled managed-system items; merely
+  available Presets that have not been installed do not contribute to the Plan.
 - `upgrade --prune-stale` removes unchanged managed App entries no longer present in the source
   through the App operation journal. User-modified stale content remains preserved; interrupted
   removal is handled by `app recover`.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/commands.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/commands.md
@@ -205,7 +205,9 @@ enrollment，不会批准之后的 lifecycle Plan。
   `--refresh-release` 组合使用。
 - `update/upgrade --pull` 会先同步 Git 管理的来源并重新加载配置。
 - 无 target 的 `upgrade` 会一次展示 Shell、App 和已启用 managed Sys 的 Plan，只确认一次，
-  并在写入前复核全部 Plan；它不再隐式修改 Sys profile 的启用状态或组合内容。
+  并在写入前复核全部 Plan；它不再隐式修改 Sys profile 的启用状态或组合内容。所需权限与
+  缺失声明检查只包含已安装的 App 类别、已安装的 Shell 命令和已启用的 managed Sys 项；
+  仅仅存在但从未安装的 Preset 不会进入 Plan。
 - `upgrade --prune-stale` 通过 App operation journal 移除预设来源中已不存在且未修改的受管
   App 条目。用户修改过的 stale 内容仍会保留；移除中断时使用 `app recover` 处理。
 - App 静态 Copy 的 effective destination 变化时，会通过一个 journaled 的旧 receipt/新 receipt


### PR DESCRIPTION
## Summary
- exclude uninstalled App presets before collecting lifecycle permissions
- prevent unused administrator capabilities and missing declarations from blocking upgrade
- add regression coverage and align English/Chinese command documentation

## Verification
- cargo test -p shine-core
- cargo clippy -p shine-core --all-targets -- -D warnings
- cargo fmt --all -- --check
- pnpm check:locales
- pnpm typecheck
- pnpm build
- typos
- git diff --check